### PR TITLE
Fix for #2

### DIFF
--- a/Source/Website/Views/CartStep1.cshtml
+++ b/Source/Website/Views/CartStep1.cshtml
@@ -59,7 +59,7 @@
                   <input name="AddOrUpdateOrderLine" type="hidden" value="orderLineId : orderLineId, quantity : quantity, overwriteQuantity : overwriteQuantity" />
                   <input name="overwriteQuantity" type="hidden" value="true" />
                   <input name="orderLineId" type="hidden" value="@orderLine.Id"/>
-                  <input type="text" name="quantity" class="form-control" value="@orderLine.Quantity.ToString( "0.####" )" readonly="" />
+                  <input type="number" name="quantity" class="form-control" value="@orderLine.Quantity.ToString( "0.####" )" pattern="[0-9]*" min="1" readonly="" />
                 </form>
                 <form action="/base/TC/FormPost.aspx" method="post">
                   <input name="storeId" type="hidden" value="@storeId"/>
@@ -81,7 +81,6 @@
                   <input name="orderLineId" type="hidden" value="@orderLine.Id"/>
                   <button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-remove"></span></button>
                 </form>
-
               </div>
             </div>
             <div class="col col-sm-2 text-right">

--- a/Source/Website/Views/Product.cshtml
+++ b/Source/Website/Views/Product.cshtml
@@ -49,7 +49,7 @@
 
           <p>
             <label for="quantity">Quantity:</label>
-            <input class="form-control" id="quantity" name="quantity" value="1" type="text" />
+            <input type="number" name="quantity" id="quantity" class="form-control" value="1" pattern="[0-9]*" min="1" />
           </p>
           <input class="btn btn-primary btn-block" value="Add to basket" type="submit" />
         </div>


### PR DESCRIPTION
Changed text input to number input with pattern attribute for a truly
number keypad on iOS devices.

I have not added additional styling, but it is possible to hide the number input spinners, e.g. if you already have buttons for increase/decrease. https://css-tricks.com/snippets/css/turn-off-number-input-spinners/

```
input[type=number]::-webkit-outer-spin-button,
input[type=number]::-webkit-inner-spin-button {
    -webkit-appearance: none;
    margin: 0;
}

input[type=number] {
    -moz-appearance:textfield;
}
```
